### PR TITLE
Change in_evaluator to use the same calculation as Sidekiq

### DIFF
--- a/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
+++ b/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
@@ -31,7 +31,7 @@ module RSpec
 
         def in_evaluator(value)
           return false if job['at'].to_s.empty?
-          (Time.now + value).to_i == Time.at(job['at']).to_i
+          (Time.now.to_f + value.to_f).to_i == Time.at(job['at']).to_i
         end
       end
 

--- a/rspec-sidekiq.gemspec
+++ b/rspec-sidekiq.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'activerecord'
   s.add_development_dependency 'activemodel'
   s.add_development_dependency 'activesupport'
+  s.add_development_dependency 'tzinfo'
 
 
   s.files = Dir['.gitattributes'] +

--- a/spec/rspec/sidekiq/matchers/have_enqueued_job_spec.rb
+++ b/spec/rspec/sidekiq/matchers/have_enqueued_job_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedJob do
   let(:tomorrow) { DateTime.now + 1 }
-  let(:interval) { 3.minutes }
+  let(:interval) { 1.day }
   let(:argument_subject) { RSpec::Sidekiq::Matchers::HaveEnqueuedJob.new worker_args }
   let(:matcher_subject) { RSpec::Sidekiq::Matchers::HaveEnqueuedJob.new [be_a(String), be_a(Integer), true, be_a(Hash)] }
   let(:worker) { create_worker }
@@ -19,6 +19,14 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedJob do
     TestActionMailer.testmail(resource).deliver_later
   end
 
+  before do
+    travel_to Time.new(2021, 3, 14, 1, 59, 59, TZInfo::Timezone.get('America/New_York'))
+  end
+
+  after do
+    travel_back
+  end
+
   describe 'expected usage' do
     context 'Sidekiq' do
       it 'matches' do
@@ -33,7 +41,7 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedJob do
         let(:worker_args_in) { worker_args + ['in'] }
 
         before(:each) do
-          worker.perform_in 3.minutes, *worker_args_in
+          worker.perform_in interval, *worker_args_in
         end
 
         it 'matches on an scheduled job with #perform_in' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,8 @@ require 'rspec-sidekiq'
 
 require 'active_job'
 require 'action_mailer'
+require 'active_support/testing/time_helpers'
+require 'tzinfo'
 
 require_relative 'support/init'
 
@@ -18,6 +20,7 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
 
   config.include RSpec::Sidekiq::Spec::Support::Factories
+  config.include ActiveSupport::Testing::TimeHelpers
 end
 
 ActiveJob::Base.queue_adapter = :sidekiq


### PR DESCRIPTION
Fixes a problem where usage of day or month `ActiveSupport::Duration`'s will calculate a different value from what Sidekiq calculates.